### PR TITLE
add supportedSelector with at-rule support

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,16 @@ exports.prefix = require('./lib/prefix')
 exports.supportedProperty = require('./lib/supported-property')
 
 /**
+ * Test if a selector is supported. Returns normal selector untouched,
+ * at-rule selector with vendor prefix if required, or false if at-rule is not supported.
+ *
+ * @param {String} selector
+ * @return {String|Boolean}
+ * @api public
+ */
+exports.supportedSelector = require('./lib/supported-selector')
+
+/**
  * Returns prefixed value if needed. Returns `false` if value is not supported.
  *
  * @param {String} property
@@ -26,4 +36,4 @@ exports.supportedProperty = require('./lib/supported-property')
  * @return {String|Boolean}
  * @api public
  */
- exports.supportedValue = require('./lib/supported-value')
+exports.supportedValue = require('./lib/supported-value')

--- a/lib/supported-selector.js
+++ b/lib/supported-selector.js
@@ -1,0 +1,73 @@
+'use strict'
+
+// Create a shortcut for the CSSRule interface
+var CSSRule = window.CSSRule
+
+// Define prefixes as they are used in this context
+var prefixes = ['MOZ_', 'WEBKIT_', 'O_', 'MS_', '']
+
+var cache = {}
+
+/**
+ * Test if a selector is supported, returns supported selector with vendor
+ * prefix if required.
+ *
+ * Returns selector if at-rule is not present.
+ * Returns at-rule if present and feature-detected. Rule is vendor prefixed if required.
+ * Returns `false` if at-rule is present and not supported.
+ *
+ * @param {String} selector
+ * @return {String|Boolean}
+ * @api public
+ */
+module.exports = function (selector) {
+    if (selector[0] !== '@') {
+        // No at-rule present to feature detect.
+        return selector
+    }
+
+    var selectorTokens = selector.split(' ')
+    var atRule = selectorTokens[0].substr(1)
+    var remainderTokens = selectorTokens.slice(1)
+    var supportedAtRule = cache[atRule] || getSupportedAtRule(atRule)
+
+    return supportedAtRule && [supportedAtRule]
+        .concat(remainderTokens)
+        .join(' ')
+}
+
+/**
+ * Test if an at-rule is supported, returns supported rule with vendor
+ * prefix if required, or false if at-rule is not supported.
+ *
+ * @param {String} selector
+ * @return {String|Boolean}
+ * @api public
+ * Feature test adapted from https://github.com/ryanmorr/is-rule-supported
+ */
+function getSupportedAtRule(atRule) {
+    // Convert the rule name to a form compatible with the CSSRule type constants
+    var rule = atRule.toUpperCase().split('-').join('_') + '_RULE'
+    var length = prefixes.length;
+    var support = false
+    var supportedPrefix
+    var result
+
+    // Loop the prefixes while support is yet to be determined
+    while (!support && length--) {
+        // Support will be tested with no prefix first before
+        // prepending each vendor prefix to the constant name and testing it
+        supportedPrefix = prefixes[length]
+        support = (supportedPrefix + rule) in CSSRule;
+    }
+
+    if (support === false) {
+        cache[atRule] = false
+        return false
+    } else if (supportedPrefix !== '') {
+        supportedPrefix = '-' + supportedPrefix.replace('_', '-').toLowerCase()
+    }
+
+    cache[atRule] = '@' + supportedPrefix + atRule
+    return cache[atRule]
+}

--- a/test/index.js
+++ b/test/index.js
@@ -45,7 +45,7 @@ test('known prefixed at-rule selector', function () {
     var selector = cssVendor.supportedSelector('@keyframes animation-name')
     var prefix = ('KEYFRAMES_RULE' in window.CSSRule) ? '' : cssVendor.prefix.css
 
-    ok(selector, '@' + prefix + 'keyframes animation-name')
+    equal(selector, '@' + prefix + 'keyframes animation-name')
 })
 
 QUnit.module('value support')

--- a/test/index.js
+++ b/test/index.js
@@ -20,12 +20,32 @@ test('known property', function () {
 })
 
 test('known property prefixed', function () {
-    var prop = cssVendor.supportedProperty('animation')
-    equal(prop, cssVendor.prefix.css + 'animation')
+    var prop = cssVendor.supportedProperty('animation-name')
+    equal(prop, cssVendor.prefix.css + 'animation-name')
 })
 
 test('unknown property', function () {
     equal(cssVendor.supportedProperty('xxx'), false)
+})
+
+QUnit.module('selector support')
+
+test('normal selector', function () {
+    equal(cssVendor.supportedSelector('.a .b'), '.a .b')
+})
+
+test('known at-rule selector', function () {
+    var importStyle = '@import url(test.css)'
+    equal(cssVendor.supportedSelector(importStyle), importStyle)
+})
+
+test('known prefixed at-rule selector', function () {
+    // There is no longer a known prefixed rule for all browsers,
+    // but checking in window.CSSRule is still a working heuristic for @keyframes
+    var selector = cssVendor.supportedSelector('@keyframes animation-name')
+    var prefix = ('KEYFRAMES_RULE' in window.CSSRule) ? '' : cssVendor.prefix.css
+
+    ok(selector, '@' + prefix + 'keyframes animation-name')
 })
 
 QUnit.module('value support')


### PR DESCRIPTION
This is in support of the first item at jsstyles/jss-vendor-prefixer#1

A corresponding PR for that library will follow that will update the selector using the result from supportedSelector.