### PR TITLE
Like to add a hardcode test for "flex" in IE10

### DIFF
--- a/lib/supported-value.js
+++ b/lib/supported-value.js
@@ -32,6 +32,9 @@ module.exports = function (property, value) {
     } else {
         // Test value with vendor prefix.
         value = prefix.css + value
+        
+        //hardcode test to convert "flex" to "-ms-flexbox" for IE10
+        if(value === "-ms-flex") value = "-ms-flexbox"
         el.style[property] = value
 
         // Value is supported with vendor prefix.


### PR DESCRIPTION
Adding a hard code test case with a value of "flex" in IE10 to test "-ms-flexbox" value instead of "-ms-flex"